### PR TITLE
Improve filtering EC2 tags.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ $ export AWS_SECRET_ACCESS_KEY=YOUR_SECRET_ACCESS_KEY
 $ export AWS_REGION=us-east-1
 ```
 
-### 4. Set the `Name` and `Vuls-Scan` tag to EC2 instance that you want to scan
+### 4. Set the `Name` and `vuls:scan` tag to EC2 instance that you want to scan
 
 e.g.
 
 ```
-Name: web-server-1
-Vuls-Scan: True
+Name : web-server-1
+vuls:scan : true
 ```
 
 ### 5. Prepare config.toml for Vuls scan
@@ -89,22 +89,30 @@ $ ec2-vuls-config --config path/to/config.toml
 #### --filters
 
 Filtering EC2 instances like [describe-instances command](http://docs.aws.amazon.com/cli/latest/reference/ec2/describe-instances.html).  
-Also, by default, filtering works that status is running, platform is linux and Vuls-Scan=True tag. 
-
+Also, by default, filtering works that status is running, platform is linux and `vuls:scan`:`true` tag.
 
 e.g.
 
-* To scan all instances with a Vuls-Scan=True tag (Default)
+* To scan all instances with a `vuls:scan`=`true` tag (Default)
 
 ```
-$ ec2-vuls-config --filters "Name=tag:Vuls-Scan,Values=True"
+$ ec2-vuls-config
+or
+$ ec2-vuls-config --filters "Name=tag:vuls:scan,Values=true"
 ```
 
-* To scan all instances with the web-server
+* To scan all instances with name of `web-server`
 
 ```
 $ ec2-vuls-config --filters "Name=tag:Name,Values=web-server"
 ```
+
+* To scan all instances with name of `db` and instance type `r3.large`
+
+```
+$ ec2-vuls-config --filters "Name=tag:Name,Values=db Name=instance-type,Values=r3.large"
+```
+
 
 ## Contribution
 

--- a/ec2-vuls-config.go
+++ b/ec2-vuls-config.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"gopkg.in/urfave/cli.v1"
 	"os"
+
+	"gopkg.in/urfave/cli.v1"
 )
 
 func main() {
@@ -16,8 +17,8 @@ func main() {
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
 			Name:  "filters, f",
-			Value: "Name=tag:Vuls-Scan,Values=True",
-			Usage: "Filtering ec2 tag",
+			Value: "",
+			Usage: "Filter options. (default: Name=tag:vuls:scan,Values=true, Name=instance-state-name,Values=running)",
 		},
 		cli.StringFlag{
 			Name:  "config, c",
@@ -28,8 +29,7 @@ func main() {
 
 	app.Action = func(c *cli.Context) error {
 
-		tag := ParseFilter(c.String("filters"))
-		instances, err := DescribeInstances(tag)
+		instances, err := DescribeInstances(c.String("filters"))
 		if err != nil {
 			return cli.NewExitError(err.Error(), 1)
 		}

--- a/ec2.go
+++ b/ec2.go
@@ -1,58 +1,74 @@
 package main
 
 import (
+	"regexp"
+	"strings"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"strings"
 )
 
-type Tag struct {
-	Name   string
-	Values string
-}
+// parseFilter parse filter command line option.
+func parseFilter(filters string) []*ec2.Filter {
 
-func ParseFilter(filters string) Tag {
-	var tag Tag
-	for _, set := range strings.Split(filters, ",") {
-		key := strings.Split(set, "=")
-		switch key[0] {
-		case "Name":
-			tag.Name = key[1]
-		case "Values":
-			tag.Values = key[1]
-		}
+	// filters e.g. "Name=tag:Foo,Values=Bar Name=instance-type,Values=m1.small"
+	var ec2Filters []*ec2.Filter
+
+	re := regexp.MustCompile(`Name=(.+),Values=(.+)`)
+	for _, i := range strings.Fields(filters) {
+		matches := re.FindAllStringSubmatch(i, -1)
+		ec2Filters = append(ec2Filters, &ec2.Filter{
+			Name: aws.String(matches[0][1]),
+			Values: []*string{
+				aws.String(matches[0][2]),
+			},
+		})
 	}
-	return tag
+	return ec2Filters
 }
 
+// generateFilter generates filter for list EC2 instances.
+func generateFilter(filters string) []*ec2.Filter {
+	var ec2Filters []*ec2.Filter
+	if len(filters) > 0 {
+		ec2Filters = parseFilter(filters)
+	}
+	// Default scan tag (vuls:scan)
+	ec2Filters = append(ec2Filters, &ec2.Filter{
+		Name: aws.String("tag:vuls:scan"),
+		Values: []*string{
+			aws.String("true"),
+		},
+	})
+	// Only running instances
+	ec2Filters = append(ec2Filters, &ec2.Filter{
+		Name: aws.String("instance-state-name"),
+		Values: []*string{
+			aws.String("running"),
+		},
+	})
+	return ec2Filters
+}
+
+// generateSession generate session.
 func generateSession() (*session.Session, error) {
 	return session.NewSessionWithOptions(session.Options{})
 }
 
-func DescribeInstances(tag Tag) ([]*ec2.Instance, error) {
+// DescribeInstances return list of EC2 instances.
+func DescribeInstances(filters string) ([]*ec2.Instance, error) {
 
 	sess, err := generateSession()
 	if err != nil {
 		return nil, err
 	}
 	svc := ec2.New(sess)
+
 	params := &ec2.DescribeInstancesInput{
-		Filters: []*ec2.Filter{
-			{
-				Name: aws.String("instance-state-name"),
-				Values: []*string{
-					aws.String("running"),
-				},
-			},
-			{
-				Name: aws.String(tag.Name),
-				Values: []*string{
-					aws.String(tag.Values),
-				},
-			},
-		},
+		Filters: generateFilter(filters),
 	}
+
 	resp, err := svc.DescribeInstances(params)
 	if err != nil {
 		return nil, err
@@ -75,6 +91,7 @@ func DescribeInstances(tag Tag) ([]*ec2.Instance, error) {
 	return instances, nil
 }
 
+// GetTagValue returns value of EC2 tag.
 func GetTagValue(instance *ec2.Instance, tag_name string) string {
 	for _, t := range instance.Tags {
 		if *t.Key == tag_name {


### PR DESCRIPTION
- Support multiple filters.
    - e.g. `--filters Name=tag:Name ,Values=db Name=instance-type,Values=t2.medium`
- Change default tag from `Vuls-Scan` to `vuls:scan`