### PR TITLE
Implement `print` and `out` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ ec2-vuls-config
 ===
 
 ec2-vuls-config is useful cli to create config file for [Vuls](https://github.com/future-architect/vuls) in Amazon EC2.
+By specifying the EC2 tag, you select the scan target Automatically and rewrite the config file.
 
 ## How to install and settings
 
@@ -51,11 +52,17 @@ See [README of Vuls](https://github.com/future-architect/vuls/blob/master/README
 
 ### Execute
 
+By default, it is filtered under the following conditions.
+
+- Status of EC2 instance is running
+- Linux (will not select Windows)
+- `vuls:scan` tag is set to `true`
+
 ```
 $ ec2-vuls-config
 ```
 
-After execute, config.toml would be generated as follows.
+After execute, config.toml would be rewrites as follows.
 
 ```
 [default]
@@ -76,30 +83,24 @@ host = "192.0.2.11"
 
 ### Options
 
-#### --config
+#### --config (-c)
 
-Specify the file path to the config.toml (Default: `$PWD/config.toml`). 
-
-e.g.
-
-```
-$ ec2-vuls-config --config path/to/config.toml
-```
-
-#### --filters
-
-Filtering EC2 instances like [describe-instances command](http://docs.aws.amazon.com/cli/latest/reference/ec2/describe-instances.html).  
-Also, by default, filtering works that status is running, platform is linux and `vuls:scan`:`true` tag.
+Specify the file path to the config.toml to be read.
+By default, `$PWD/config.toml`.
 
 e.g.
 
-* To scan all instances with a `vuls:scan`=`true` tag (Default)
+```
+$ ec2-vuls-config --config /path/to/config.toml
+```
 
-```
-$ ec2-vuls-config
-or
-$ ec2-vuls-config --filters "Name=tag:vuls:scan,Values=true"
-```
+#### --filters (-f)
+
+In addition to the default condition, it is used for further filter.
+This option like [describe-instances command](http://docs.aws.amazon.com/cli/latest/reference/ec2/describe-instances.html).
+Specify Name and Value and separate with a space.
+
+e.g.
 
 * To scan all instances with name of `web-server`
 
@@ -107,12 +108,27 @@ $ ec2-vuls-config --filters "Name=tag:vuls:scan,Values=true"
 $ ec2-vuls-config --filters "Name=tag:Name,Values=web-server"
 ```
 
-* To scan all instances with name of `db` and instance type `r3.large`
+* To scan all instances with name of `app-server` and instance type `c3.large`
 
 ```
-$ ec2-vuls-config --filters "Name=tag:Name,Values=db Name=instance-type,Values=r3.large"
+$ ec2-vuls-config --filters "Name=tag:Name,Values=app-server Name=instance-type,Values=r3.large"
 ```
 
+#### --out (-o)
+
+Specify the path of the config file to be written.
+By default, `$PWD/config.toml`.
+
+e.g.
+
+```
+$ ec2-vuls-config --out /path/to/config.toml
+```
+
+
+#### --print (-p)
+
+Echo the standard output instead of write into specified config file.
 
 ## Contribution
 

--- a/ec2-vuls-config.go
+++ b/ec2-vuls-config.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"gopkg.in/urfave/cli.v1"
@@ -17,13 +18,16 @@ func main() {
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
 			Name:  "filters, f",
-			Value: "",
 			Usage: "Filter options. (default: Name=tag:vuls:scan,Values=true, Name=instance-state-name,Values=running)",
 		},
 		cli.StringFlag{
 			Name:  "config, c",
 			Value: os.Getenv("PWD") + "/config.toml",
 			Usage: "Load configuration from `FILE`",
+		},
+		cli.BoolFlag{
+			Name:  "print, p",
+			Usage: "Echo the standard output instead of apend specified config file.",
 		},
 	}
 
@@ -40,9 +44,13 @@ func main() {
 		}
 
 		new_config := CreateConfig(GenerateServerSection(instances), config)
-		err = WriteFile(c.String("config"), new_config)
-		if err != nil {
-			return cli.NewExitError(err.Error(), 1)
+		if c.Bool("print") {
+			fmt.Println(string(new_config))
+		} else {
+			err = WriteFile(c.String("config"), new_config)
+			if err != nil {
+				return cli.NewExitError(err.Error(), 1)
+			}
 		}
 		return nil
 	}

--- a/ec2-vuls-config.go
+++ b/ec2-vuls-config.go
@@ -32,7 +32,7 @@ func main() {
 		},
 		cli.BoolFlag{
 			Name:  "print, p",
-			Usage: "Echo the standard output instead of apend specified config file",
+			Usage: "Echo the standard output instead of write into specified config file.",
 		},
 	}
 

--- a/ec2-vuls-config.go
+++ b/ec2-vuls-config.go
@@ -18,16 +18,21 @@ func main() {
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
 			Name:  "filters, f",
-			Usage: "Filter options. (default: Name=tag:vuls:scan,Values=true, Name=instance-state-name,Values=running)",
+			Usage: "Filter options (default: Name=tag:vuls:scan,Values=true, Name=instance-state-name,Values=running)",
 		},
 		cli.StringFlag{
 			Name:  "config, c",
 			Value: os.Getenv("PWD") + "/config.toml",
-			Usage: "Load configuration from `FILE`",
+			Usage: "Config file path",
+		},
+		cli.StringFlag{
+			Name:  "out, o",
+			Value: os.Getenv("PWD") + "/config.toml",
+			Usage: "Output file path of config",
 		},
 		cli.BoolFlag{
 			Name:  "print, p",
-			Usage: "Echo the standard output instead of apend specified config file.",
+			Usage: "Echo the standard output instead of apend specified config file",
 		},
 	}
 
@@ -47,7 +52,7 @@ func main() {
 		if c.Bool("print") {
 			fmt.Println(string(new_config))
 		} else {
-			err = WriteFile(c.String("config"), new_config)
+			err = WriteFile(c.String("out"), new_config)
 			if err != nil {
 				return cli.NewExitError(err.Error(), 1)
 			}


### PR DESCRIPTION
## `print` option

Echo the standard output instead of write into specified config file.
We mainly assume debugging purpose.

## `out` option

Specify the path of the config file to be written.
It will be used if you can write files only on certain paths such as AWS Lambda.